### PR TITLE
Add broken links CI check and fix broken links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+
+node_js:
+  - "7"
+
+before_script: 
+  - make install-link-check
+
+script:
+  - make link-check

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:latest
+
+ADD Makefile .
+
+RUN make install-link-check
+
+ADD . .

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+SHELL = /bin/bash -eo pipefail
+
+.PHONY: install-link-check link-check build-container docker-link-check
+
+install-link-check:
+	npm install -g markdown-link-check
+
+link-check:
+	@if ! which markdown-link-check > /dev/null;\
+	then \
+		echo "markdown-link-check not in PATH. Install it with 'make install-link-check'" ;\
+		exit 1 ;\
+	fi
+	markdown-link-check README.md
+
+build-container:
+	docker build -t link-check .
+
+docker-link-check: build-container
+	docker run link-check make link-check

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Awesome papers and presentations related to networking
 
 # Scaling
 
-* [Partially FIBing](https://www.nanog.org/sites/default/files/20161010_Jaeggli_Partially_Fibing__v2.pdf)
+* [Partially FIBing](https://archive.nanog.org/sites/default/files/20161010_Jaeggli_Partially_Fibing__v2.pdf)
 
 # SDN
 


### PR DESCRIPTION
This commit adds a .travis.yml file that enables checking the integrity of all links in README.md in Travis CI at each pull request and also periodically if we want to. It also adds a Dockerfile and a Makefile that makes it possible to run the same check locally in a Docker container.

This commit also fixes a broken link in README.md.